### PR TITLE
Dony/player system

### DIFF
--- a/Quoridor/Assets/Scripts/Player/AreaAbility.cs
+++ b/Quoridor/Assets/Scripts/Player/AreaAbility.cs
@@ -26,6 +26,7 @@ public class AreaAbility : MonoBehaviour
     EnemyManager enemyManager;
     Player player;
     List<BoxCollider2D> boxColliderList = new List<BoxCollider2D>();
+    List<GameObject> areaObjectList = new List<GameObject>();
     // Start is called before the first frame update
     void Start()
     {
@@ -43,14 +44,17 @@ public class AreaAbility : MonoBehaviour
             if (result[0])
             {
                 boxColliderList[i].enabled = false;
+                areaObjectList[i].SetActive(false);
             }
             if (result[1] || canPenetrate)
             {
                 boxColliderList[i].enabled = true;
+                areaObjectList[i].SetActive(true);
             }
             else
             {
                 boxColliderList[i].enabled = false;
+                areaObjectList[i].SetActive(false);
             }
         }
         if (GameManager.Turn % 2 == Player.playerOrder && tempTurn != GameManager.Turn)
@@ -75,7 +79,8 @@ public class AreaAbility : MonoBehaviour
             boxColliderList.Add(boxCollider);
 
             // 임시 //
-            Instantiate(sprite, this.transform).transform.localPosition = (Vector2)areaPositionList[i];
+            areaObjectList.Add(Instantiate(sprite, this.transform));
+            areaObjectList[i].transform.localPosition = (Vector2)areaPositionList[i];
         }
     }
     void OnAbilityDisable()

--- a/Quoridor/Assets/Scripts/Player/AreaAbility.cs
+++ b/Quoridor/Assets/Scripts/Player/AreaAbility.cs
@@ -97,7 +97,10 @@ public class AreaAbility : MonoBehaviour
             enterEvent(other.GetComponent<Enemy>());
             if (lifeType == ELifeType.Count)
             {
-                OnAbilityDisable();
+                if (--life == 0)
+                {
+                    OnAbilityDisable();
+                }
             }
         }
     }

--- a/Quoridor/Assets/Scripts/Player/PlayerAbility.cs
+++ b/Quoridor/Assets/Scripts/Player/PlayerAbility.cs
@@ -1415,7 +1415,7 @@ public class PlayerAbility : MonoBehaviour
         public ExitEvent exitEvent { get { return (Enemy enemy) => { }; } }
         public bool Event()
         {
-            Debug.Log($"{targetPos}");
+            // Debug.Log($"{targetPos}");
             mValue = 2 + thisScript.additionalAbilityStat.placeDamage;
             thisScript.SetAreaAbility(AreaAbility.ELifeType.Count, 1, targetPos, attackScale, canPenetrate[1], enterEvent, stayEvent, exitEvent);
             mCount--;


### PR DESCRIPTION
AreaAbility가 Count 타입일 때 life에 상관없이 항상 삭제되는 버그 수정
AreaAbility의 Sprite가 boxCollider 활성 여부에 따라 달라지게 함